### PR TITLE
fix: map Firestore doc id in loadThings

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -4,5 +4,10 @@ export async function loadThings() {
   const col = await FirebaseApp.firestore().collection("things");
   const docs = await col.orderBy('name').limit(25).get();
 
-  return docs.docs.map(doc => doc.data());
+  return docs.docs.map(doc => {
+    return {
+      id: doc.id,
+      ...doc.data()
+    }
+  });
 }


### PR DESCRIPTION
Hey Max,

I'm not sure, without knowing the exact db structure, but I'm guessing that the Firestore document Id should be mapped too as it is use as item's key in the Home component (`<IonItem key={item.id}>{item.name}</IonItem>`).

Best
